### PR TITLE
Dockerize 2 Eve nodes via compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github/
+.testnets/
+.vscode/
+networks/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# docker build . -t notionallabs/eve:latest
+# docker run --rm -it notionallabs/eve /bin/sh
+
+FROM archlinux
+
+# install packages
+RUN pacman -Sy --noconfirm go 
+RUN pacman -Sy --noconfirm archlinux-keyring 
+RUN pacman -Sy --noconfirm make gcc base jq
+
+# set working directory
+WORKDIR /app
+
+# copy the current directory contents into the container at /usr/src/app
+COPY . .
+
+ENV PATH "$PATH:/root/go/bin"
+
+RUN make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# docker build . -t notionallabs/eve:latest
-# docker run --rm -it notionallabs/eve /bin/sh
+# docker build . -t notional-labs/eve:latest
+# docker run --rm -it notional-labs/eve /bin/sh
 
 FROM archlinux
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ COPY . .
 
 ENV PATH "$PATH:/root/go/bin"
 
+EXPOSE 26656 26657 1317 9090
+
 RUN make install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,13 +14,14 @@ services:
     security_opt:
       - seccomp:unconfined
     ports:
-      - "26656-26657:26656-26657"
+      - "26657:26657"
+      - "26656:26656"      
       - "1317:1317"
       - "9090:9090"
       - "8080:8080"
     volumes:      
       - ./docker/.testnets/v1:/root/.eved/:rw      
-    command: eved start --home /root/.eved/ --moniker dockereve1 --p2p.persistent_peers "017e3b0c9a050091cc2bc609af9fb861d3710215@192.168.11.3:26666"
+    command: eved start --home /root/.eved/ --moniker dockereve1 --p2p.persistent_peers "c209ee97b631df98923cadd9667bd61d879e2e1a@evenode2:26666"
     # command: ls /root/.eved/config
     networks:
       localnet:
@@ -39,13 +40,14 @@ services:
     security_opt:
       - seccomp:unconfined
     ports:
-      - "26666-26667:26666-26667"
+      - "26667:26667"
+      - "26666:26666"
       - "1327:1317"
       - "9101:9101"
       - "9100:9100"        
     volumes:      
       - ./docker/.testnets/v2:/root/.eved/:rw 
-    command: eved start --home /root/.eved/ --moniker dockereve2 --address "tcp://0.0.0.0:26668" --grpc-web.address "0.0.0.0:9101" --grpc.address "0.0.0.0:9100" --p2p.laddr "tcp://127.0.0.1:26666" --rpc.laddr "tcp://127.0.0.1:26667" --proxy_app "tcp://127.0.0.1:26668" --p2p.persistent_peers "017e3b0c9a050091cc2bc609af9fb861d3710215@192.168.11.2:26656" # --api.address "tcp://0.0.0.0:1327"
+    command: eved start --home /root/.eved/ --moniker dockereve2 --address "tcp://evenode2:26668" --grpc-web.address "evenode2:9101" --grpc.address "evenode2:9100" --p2p.laddr "tcp://evenode2:26666" --rpc.laddr "tcp://evenode2:26667" --proxy_app "tcp://evenode2:26668" --p2p.persistent_peers "c209ee97b631df98923cadd9667bd61d879e2e1a@evenode1:26656" # --api.address "tcp://0.0.0.0:1327"
     # command: ls /root/.eved/config
     networks:
       localnet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,14 @@
 version: "3"
 
 services:
-  simdnode0:
-    container_name: simdnode0
-    image: "notionallabs/eve"
+  evenode1:
+    container_name: evenode1
+    image: "notional-labs/eve"
+    # build: .
     environment:
       - DEBUG=1
       - ID=0
-      - LOG=${LOG:-simd.log}
+      - LOG=${LOG:-eved.log}
     cap_add:
       - SYS_PTRACE
     security_opt:
@@ -16,34 +17,39 @@ services:
       - "26656-26657:26656-26657"
       - "1317:1317"
       - "9090:9090"
-      - "2345:2345"
-    volumes:
-      - ./.testnets:/data:Z
+      - "8080:8080"
+    volumes:      
+      - ./docker/.testnets/v1:/root/.eved/:rw      
+    command: eved start --home /root/.eved/ --moniker dockereve1 --p2p.persistent_peers "017e3b0c9a050091cc2bc609af9fb861d3710215@192.168.11.3:26666"
+    # command: ls /root/.eved/config
     networks:
       localnet:
-        ipv4_address: 192.168.10.2
+        ipv4_address: 192.168.11.2
 
-  simdnode1:
-    container_name: simdnode1
-    image: "notionallabs/eve"
+  evenode2:
+    container_name: evenode2
+    image: "notional-labs/eve"
+    # build: .
     environment:
-      - DEBUG=0
-      - ID=1
-      - LOG=${LOG:-simd.log}
+      - DEBUG=1
+      - ID=0
+      - LOG=${LOG:-eved.log}
     cap_add:
       - SYS_PTRACE
     security_opt:
       - seccomp:unconfined
     ports:
-      - "26666-26667:26656-26657"
-      - "1318:1317"
-      - "9091:9090"
-      - "2346:2345"
-    volumes:
-      - ./.testnets:/data:Z
+      - "26666-26667:26666-26667"
+      - "1327:1317"
+      - "9101:9101"
+      - "9100:9100"        
+    volumes:      
+      - ./docker/.testnets/v2:/root/.eved/:rw 
+    command: eved start --home /root/.eved/ --moniker dockereve2 --address "tcp://0.0.0.0:26668" --grpc-web.address "0.0.0.0:9101" --grpc.address "0.0.0.0:9100" --p2p.laddr "tcp://127.0.0.1:26666" --rpc.laddr "tcp://127.0.0.1:26667" --proxy_app "tcp://127.0.0.1:26668" --p2p.persistent_peers "017e3b0c9a050091cc2bc609af9fb861d3710215@192.168.11.2:26656" # --api.address "tcp://0.0.0.0:1327"
+    # command: ls /root/.eved/config
     networks:
       localnet:
-        ipv4_address: 192.168.10.3
+        ipv4_address: 192.168.11.3
 
 networks:
   localnet:
@@ -51,4 +57,5 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 192.168.10.0/25
+        - subnet: 192.168.11.0/25
+          gateway: 192.168.11.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: "3"
+
+services:
+  simdnode0:
+    container_name: simdnode0
+    image: "notionallabs/eve"
+    environment:
+      - DEBUG=1
+      - ID=0
+      - LOG=${LOG:-simd.log}
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
+    ports:
+      - "26656-26657:26656-26657"
+      - "1317:1317"
+      - "9090:9090"
+      - "2345:2345"
+    volumes:
+      - ./.testnets:/data:Z
+    networks:
+      localnet:
+        ipv4_address: 192.168.10.2
+
+  simdnode1:
+    container_name: simdnode1
+    image: "notionallabs/eve"
+    environment:
+      - DEBUG=0
+      - ID=1
+      - LOG=${LOG:-simd.log}
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
+    ports:
+      - "26666-26667:26656-26657"
+      - "1318:1317"
+      - "9091:9090"
+      - "2346:2345"
+    volumes:
+      - ./.testnets:/data:Z
+    networks:
+      localnet:
+        ipv4_address: 192.168.10.3
+
+networks:
+  localnet:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.10.0/25

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,8 @@
+### Run 2 Eve validators easily
+
+Steps
+```bash
+# From the root of this project folder,
+- sh docker/init.sh # performs: gentxs, collection, add account balances, genesis file & manupulation, 
+- docker-compose up # mounts to the docker's testnet folder to use validators 1 and 2 unique dirs. Also uses ports +10
+```

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -82,7 +82,7 @@ cp $TESTNETS_SHARED_DIR/config/genesis.json $V1/config/genesis.json
 eved add-genesis-account eve1hj5fveer5cjtn4wd6wstzugjfdxzl0xpysfwwn 100000000ueve --keyring-backend $KEYRING --home $V1
 eved add-genesis-account eve1hj5fveer5cjtn4wd6wstzugjfdxzl0xpysfwwn 100000000ueve --keyring-backend $KEYRING --home $TESTNETS_SHARED_DIR # also add to main genesis
 
-eved gentx $KEY 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V1 --moniker $MONIKER1 --commission-rate=0.05 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" #--node-id aaae33661a8286150ad54a512b04bbb96e72b68a --ip 127.0.0.1
+eved gentx $KEY 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V1 --moniker $MONIKER1 --commission-rate=0.10 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" #--node-id aaae33661a8286150ad54a512b04bbb96e72b68a --ip 127.0.0.1
 
 # Key 2.
 mkdir -p $V2/config
@@ -91,7 +91,7 @@ cp $TESTNETS_SHARED_DIR/config/genesis.json $V2/config/genesis.json
 eved add-genesis-account eve1j4rtuq6zm5mmw9xcjmm7gymlj39tvwnt9h4sm2 100000000ueve --keyring-backend $KEYRING --home $V2
 eved add-genesis-account eve1j4rtuq6zm5mmw9xcjmm7gymlj39tvwnt9h4sm2 100000000ueve --keyring-backend $KEYRING --home $TESTNETS_SHARED_DIR
 
-eved gentx $KEY2 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V2 --moniker $MONIKER2 --commission-rate=0.05 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" #--node-id bbbe33661a8286150ad54a512b04bbb96e72b68a  --ip 127.0.0.1 
+eved gentx $KEY2 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V2 --moniker $MONIKER2 --commission-rate=0.10 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" #--node-id bbbe33661a8286150ad54a512b04bbb96e72b68a  --ip 127.0.0.1 
 
 # save gentxs back to the root dir
 mkdir -p $TESTNETS_SHARED_DIR/config/gentx
@@ -123,11 +123,7 @@ cp $TESTNETS_SHARED_DIR/config/genesis.json $V2/config/genesis.json
 
 # moniker 1 starts a node normally with default values
 echo -e "\nStarting the first node ($V1)"
-echo eved start --home $V1 --minimum-gas-prices=0ueve --moniker $MONIKER1 --address "tcp://0.0.0.0:26658" --api.address "tcp://0.0.0.0:1317" --grpc-web.address "0.0.0.0:9091" --grpc.address "0.0.0.0:9090" --p2p.laddr "tcp://127.0.0.1:26656" --rpc.laddr "tcp://127.0.0.1:26657" --proxy_app "tcp://127.0.0.1:26658" --p2p.persistent_peers "bbbe33661a8286150ad54a512b04bbb96e72b68a@127.0.0.1:26667"
-# screen -dmS n1 eved start --home $V1 --minimum-gas-prices=0ueve --moniker $MONIKER1 --address "tcp://0.0.0.0:26658" --api.address "tcp://0.0.0.0:1317" --grpc-web.address "0.0.0.0:9091" --grpc.address "0.0.0.0:9090" --p2p.laddr "tcp://127.0.0.1:26656" --rpc.laddr "tcp://127.0.0.1:26657" --proxy_app "tcp://127.0.0.1:26658" --p2p.persistent_peers "bbbe33661a8286150ad54a512b04bbb96e72b68a@127.0.0.1:26667"
+screen -dmS n1 eved start --home $V1 --moniker $MONIKER1 --address "tcp://0.0.0.0:26658" --api.address "tcp://0.0.0.0:1317" --grpc-web.address "0.0.0.0:9091" --grpc.address "0.0.0.0:9090" --p2p.laddr "tcp://127.0.0.1:26656" --rpc.laddr "tcp://127.0.0.1:26657" --proxy_app "tcp://127.0.0.1:26658" --p2p.persistent_peers "bbbe33661a8286150ad54a512b04bbb96e72b68a@127.0.0.1:26667"
 
 echo -e "\nStarting the second node ($V2)"
-# screen -dmS n2 eved start --home $V2 --minimum-gas-prices=0ueve --moniker $MONIKER2 --address "tcp://0.0.0.0:26668" --api.address "tcp://0.0.0.0:1327" --grpc-web.address "0.0.0.0:9101" --grpc.address "0.0.0.0:9100" --p2p.laddr "tcp://127.0.0.1:26666" --rpc.laddr "tcp://127.0.0.1:26667" --proxy_app "tcp://127.0.0.1:26668" --p2p.persistent_peers "aaae33661a8286150ad54a512b04bbb96e72b68a@127.0.0.1:26657"
-
-# we start in the docker containers here / via compose
-# eved start --pruning=nothing  --minimum-gas-prices=0ueve --moniker $MONIKER1 --home $V1
+screen -dmS n2 eved start --home $V2 --moniker $MONIKER2 --address "tcp://0.0.0.0:26668" --api.address "tcp://0.0.0.0:1327" --grpc-web.address "0.0.0.0:9101" --grpc.address "0.0.0.0:9100" --p2p.laddr "tcp://127.0.0.1:26666" --rpc.laddr "tcp://127.0.0.1:26667" --proxy_app "tcp://127.0.0.1:26668" --p2p.persistent_peers "aaae33661a8286150ad54a512b04bbb96e72b68a@127.0.0.1:26657"

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -122,12 +122,11 @@ cp -r $TESTNETS_SHARED_DIR/config/config.toml $V2/config/config.toml
 cp $TESTNETS_SHARED_DIR/config/genesis.json $V1/config/genesis.json
 cp $TESTNETS_SHARED_DIR/config/genesis.json $V2/config/genesis.json
 
-read -p "Press enter to continue"
 
-# goal is to do this via each docker container. I guess we could support screens too if someone wanted that
-# 6:04PM INF Error reconnecting to peer. Trying again addr={"id":"aaae33661a8286150ad54a512b04bbb96e72b68a","ip":"127.0.0.1","port":26657} err="auth failure: secret conn failed: proto: BytesValue: wiretype end group for non-group" module=p2p tries=0
-echo -e "\nStarting the first node ($V1)"
-screen -dmS n1 eved start --home $V1 --moniker $MONIKER1 --address "tcp://0.0.0.0:26658" --api.address "tcp://0.0.0.0:1317" --grpc-web.address "0.0.0.0:9091" --grpc.address "0.0.0.0:9090" --p2p.laddr "tcp://127.0.0.1:26656" --rpc.laddr "tcp://127.0.0.1:26657" --proxy_app "tcp://127.0.0.1:26658" --p2p.persistent_peers "017e3b0c9a050091cc2bc609af9fb861d3710215@127.0.0.1:26666"
+# Uncomment below to use screens n1 and n2 over 'docker-compose up'
+# echo -e "\nStarting the first node ($V1)"
+# screen -dmS n1 eved start --home $V1 --moniker $MONIKER1 --address "tcp://0.0.0.0:26658" --api.address "tcp://0.0.0.0:1317" --grpc-web.address "0.0.0.0:9091" --grpc.address "0.0.0.0:9090" --p2p.laddr "tcp://127.0.0.1:26656" --rpc.laddr "tcp://127.0.0.1:26657" --proxy_app "tcp://127.0.0.1:26658" --p2p.persistent_peers "017e3b0c9a050091cc2bc609af9fb861d3710215@127.0.0.1:26666"
+# echo -e "\nStarting the second node ($V2)"
+# screen -dmS n2 eved start --home $V2 --moniker $MONIKER2 --address "tcp://0.0.0.0:26668" --api.address "tcp://0.0.0.0:1327" --grpc-web.address "0.0.0.0:9101" --grpc.address "0.0.0.0:9100" --p2p.laddr "tcp://127.0.0.1:26666" --rpc.laddr "tcp://127.0.0.1:26667" --proxy_app "tcp://127.0.0.1:26668" --p2p.persistent_peers "017e3b0c9a050091cc2bc609af9fb861d3710215@127.0.0.1:26656"
 
-echo -e "\nStarting the second node ($V2)"
-screen -dmS n2 eved start --home $V2 --moniker $MONIKER2 --address "tcp://0.0.0.0:26668" --api.address "tcp://0.0.0.0:1327" --grpc-web.address "0.0.0.0:9101" --grpc.address "0.0.0.0:9100" --p2p.laddr "tcp://127.0.0.1:26666" --rpc.laddr "tcp://127.0.0.1:26667" --proxy_app "tcp://127.0.0.1:26668" --p2p.persistent_peers "017e3b0c9a050091cc2bc609af9fb861d3710215@127.0.0.1:26656"
+echo "Run 'docker-compose up' now to start the 2 containers"

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,109 @@
+# call on build to make a new folder which we can mount too via compose.
+# this way we can build each node to share the latests gentx
+# most commands taken from ./test_node.sh
+
+CHAINID="eve-d"  # eve-docker
+KEYALGO="secp256k1"
+KEYRING="test"  # export EVE_KEYRING="TEST"
+LOGLEVEL="info"
+KEY="eve1"      # eve1hj5fveer5cjtn4wd6wstzugjfdxzl0xpysfwwn
+MONIKER1="dockereve1"
+KEY2="eve2"     # eve1j4rtuq6zm5mmw9xcjmm7gymlj39tvwnt9h4sm2
+MONIKER2="dockereve2"
+
+# File Location
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TESTNETS_SHARED_DIR=$SCRIPT_DIR/.testnets
+# check that SCRIPT_DIR is longer than 7, if so delete the .testnets folder for a fresh start
+if [ ${#SCRIPT_DIR} -gt 7 ]; then
+  echo "$SCRIPT_DIR"
+  rm -rf $SCRIPT_DIR/.testnets
+fi
+
+V1=$SCRIPT_DIR/.testnets/v1
+V2=$SCRIPT_DIR/.testnets/v2
+
+# init chain from key 1, giving us a fresh new genesis with latests features
+eved init $MONIKER1 --chain-id $CHAINID --home $TESTNETS_SHARED_DIR
+
+# key1 - eve1hj5fveer5cjtn4wd6wstzugjfdxzl0xpysfwwn
+echo "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry" | eved keys add $KEY --keyring-backend $KEYRING --algo $KEYALGO --home $V1 --recover
+# key2 - eve1j4rtuq6zm5mmw9xcjmm7gymlj39tvwnt9h4sm2
+echo "yard toss ritual ticket dirt address hood stock shiver add client sketch still brave pen win affair orphan employ choose dream sail slogan poverty" | eved keys add $KEY2 --keyring-backend $KEYRING --algo $KEYALGO --home $V2 --recover
+
+# Do via docker?
+eved config keyring-backend $KEYRING
+eved config chain-id $CHAINID
+eved config output "json"
+
+
+# mkdir $V1 $V2
+
+# Function updates the config based on a jq argument as a string
+update_test_genesis () {
+    # update_test_genesis '.consensus_params["block"]["max_gas"]="100000000"'
+    cat $TESTNETS_SHARED_DIR/config/genesis.json | jq "$1" > $TESTNETS_SHARED_DIR/tmp_genesis.json && mv $TESTNETS_SHARED_DIR/tmp_genesis.json $TESTNETS_SHARED_DIR/config/genesis.json
+}
+# Set gas limit in genesis
+update_test_genesis '.consensus_params["block"]["max_gas"]="100000000"'
+update_test_genesis '.app_state["gov"]["voting_params"]["voting_period"]="15s"'
+# Change chain options to use EXP as the staking denom for craft
+update_test_genesis '.app_state["staking"]["params"]["bond_denom"]="ueve"'
+update_test_genesis '.app_state["staking"]["params"]["min_commission_rate"]="0.100000000000000000"'
+# update from token -> ueve
+update_test_genesis '.app_state["mint"]["params"]["mint_denom"]="ueve"'  
+update_test_genesis '.app_state["gov"]["deposit_params"]["min_deposit"]=[{"denom": "ueve","amount": "1000000"}]' # 1 eve right now
+update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": "ueve","amount": "1000"}'
+
+
+# Key 1, copy genesis -> $V1, add gen account, gentx
+mkdir -p $V1/config
+cp $TESTNETS_SHARED_DIR/config/genesis.json $V1/config/genesis.json
+
+eved add-genesis-account eve1hj5fveer5cjtn4wd6wstzugjfdxzl0xpysfwwn 100000000ueve --keyring-backend $KEYRING --home $V1
+eved add-genesis-account eve1hj5fveer5cjtn4wd6wstzugjfdxzl0xpysfwwn 100000000ueve --keyring-backend $KEYRING --home $TESTNETS_SHARED_DIR # also add to main genesis
+eved gentx $KEY 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --moniker $MONIKER1 -home $V1 --ip 127.0.0.1 #--node-id aaae33661a8286150ad54a512b04bbb96e72b68a -
+
+# Key 2.
+mkdir -p $V2/config
+cp $TESTNETS_SHARED_DIR/config/genesis.json $V2/config/genesis.json
+
+eved add-genesis-account eve1j4rtuq6zm5mmw9xcjmm7gymlj39tvwnt9h4sm2 100000000ueve --keyring-backend $KEYRING --home $V2
+eved add-genesis-account eve1j4rtuq6zm5mmw9xcjmm7gymlj39tvwnt9h4sm2 100000000ueve --keyring-backend $KEYRING --home $TESTNETS_SHARED_DIR
+eved gentx $KEY2 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V2 --moniker $MONIKER2 --ip 127.0.0.1 #--node-id bbbe33661a8286150ad54a512b04bbb96e72b68a 
+
+# save gentxs back to the root dir
+mkdir -p $TESTNETS_SHARED_DIR/config/gentx
+cp $V1/config/gentx/*.json $TESTNETS_SHARED_DIR/config/gentx
+cp $V2/config/gentx/*.json $TESTNETS_SHARED_DIR/config/gentx
+
+# read -p "Press enter to continue"
+
+eved collect-gentxs --gentx-dir $TESTNETS_SHARED_DIR/config/gentx --home $TESTNETS_SHARED_DIR
+eved validate-genesis --home $TESTNETS_SHARED_DIR
+
+# Opens the RPC endpoint to outside connections
+
+# upda the main dirs config toml which we want to persist across both chains values
+sed -i '/laddr = "tcp:\/\/127.0.0.1:26657"/c\laddr = "tcp:\/\/0.0.0.0:26657"' $TESTNETS_SHARED_DIR/config/config.toml
+sed -i 's/cors_allowed_origins = \[\]/cors_allowed_origins = \["\*"\]/g' $TESTNETS_SHARED_DIR/config/config.toml
+# copy to the other 2 dirs
+mkdir -p $V1/config/ $V2/config/
+cp -r $TESTNETS_SHARED_DIR/config/config.toml $V1/config/config.toml
+cp -r $TESTNETS_SHARED_DIR/config/config.toml $V2/config/config.toml
+
+
+# copy main genesis to each dir folder
+cp $TESTNETS_SHARED_DIR/config/genesis.json $V1/config/genesis.json
+cp $TESTNETS_SHARED_DIR/config/genesis.json $V2/config/genesis.json
+
+
+# moniker 1 starts a node normally with default values
+echo -e "\nStarting the first node ($V1)"
+screen -dmS node1 eved start --home $V1 --minimum-gas-prices=0ueve --moniker $MONIKER1 --address "tcp://0.0.0.0:26658" --api.address "tcp://0.0.0.0:1317" --grpc-web.address "0.0.0.0:9091" --grpc.address "0.0.0.0:9090" --p2p.laddr "tcp://127.0.0.1:26656" --rpc.laddr "tcp://127.0.0.1:26657" --proxy_app "tcp://127.0.0.1:26658" --p2p.persistent_peers "bbbe33661a8286150ad54a512b04bbb96e72b68a@127.0.0.1:26667"
+
+echo -e "\nStarting the second node ($V2)"
+screen -dmS node2 eved start --home $V2 --minimum-gas-prices=0ueve --moniker $MONIKER2 --address "tcp://0.0.0.0:26668" --api.address "tcp://0.0.0.0:1327" --grpc-web.address "0.0.0.0:9101" --grpc.address "0.0.0.0:9100" --p2p.laddr "tcp://127.0.0.1:26666" --rpc.laddr "tcp://127.0.0.1:26667" --proxy_app "tcp://127.0.0.1:26668" --p2p.persistent_peers "aaae33661a8286150ad54a512b04bbb96e72b68a@127.0.0.1:26657"
+
+# we start in the docker containers here / via compose
+# eved start --pruning=nothing  --minimum-gas-prices=0ueve --moniker $MONIKER1 --home $V1

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -77,7 +77,7 @@ cp $TESTNETS_SHARED_DIR/config/genesis.json $V1/config/genesis.json
 eved add-genesis-account eve1hj5fveer5cjtn4wd6wstzugjfdxzl0xpysfwwn 100000000ueve --keyring-backend $KEYRING --home $V1
 eved add-genesis-account eve1hj5fveer5cjtn4wd6wstzugjfdxzl0xpysfwwn 100000000ueve --keyring-backend $KEYRING --home $TESTNETS_SHARED_DIR # also add to main genesis
 
-eved gentx $KEY 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V1 --moniker $MONIKER1 --commission-rate=0.10 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" --ip 127.0.0.1
+eved gentx $KEY 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V1 --moniker $MONIKER1 --commission-rate=0.10 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" --ip 127.0.0.1 --node-id 017e3b0c9a050091cc2bc609af9fb861d3710215
 
 # Key 2.
 mkdir -p $V2/config
@@ -86,10 +86,10 @@ cp $TESTNETS_SHARED_DIR/config/genesis.json $V2/config/genesis.json
 eved add-genesis-account eve1j4rtuq6zm5mmw9xcjmm7gymlj39tvwnt9h4sm2 100000000ueve --keyring-backend $KEYRING --home $V2
 eved add-genesis-account eve1j4rtuq6zm5mmw9xcjmm7gymlj39tvwnt9h4sm2 100000000ueve --keyring-backend $KEYRING --home $TESTNETS_SHARED_DIR
 
-eved gentx $KEY2 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V2 --moniker $MONIKER2 --commission-rate=0.10 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" --ip 127.0.0.1
+eved gentx $KEY2 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V2 --moniker $MONIKER2 --commission-rate=0.10 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" --ip 127.0.0.1 --node-id 017e3b0c9a050091cc2bc609af9fb861d3710215
 
-KEY1_NODE_ID=`eved tendermint show-node-id --home $V1`
-KEY2_NODE_ID=`eved tendermint show-node-id --home $V2`
+# KEY1_NODE_ID=`eved tendermint show-node-id --home $V1`
+# KEY2_NODE_ID=`eved tendermint show-node-id --home $V2`
 
 # save gentxs back to the root dir
 mkdir -p $TESTNETS_SHARED_DIR/config/gentx
@@ -127,7 +127,7 @@ read -p "Press enter to continue"
 # goal is to do this via each docker container. I guess we could support screens too if someone wanted that
 # 6:04PM INF Error reconnecting to peer. Trying again addr={"id":"aaae33661a8286150ad54a512b04bbb96e72b68a","ip":"127.0.0.1","port":26657} err="auth failure: secret conn failed: proto: BytesValue: wiretype end group for non-group" module=p2p tries=0
 echo -e "\nStarting the first node ($V1)"
-screen -dmS n1 eved start --home $V1 --moniker $MONIKER1 --address "tcp://0.0.0.0:26658" --api.address "tcp://0.0.0.0:1317" --grpc-web.address "0.0.0.0:9091" --grpc.address "0.0.0.0:9090" --p2p.laddr "tcp://127.0.0.1:26656" --rpc.laddr "tcp://127.0.0.1:26657" --proxy_app "tcp://127.0.0.1:26658" --p2p.persistent_peers "$KEY2_NODE_ID@127.0.0.1:26666"
+screen -dmS n1 eved start --home $V1 --moniker $MONIKER1 --address "tcp://0.0.0.0:26658" --api.address "tcp://0.0.0.0:1317" --grpc-web.address "0.0.0.0:9091" --grpc.address "0.0.0.0:9090" --p2p.laddr "tcp://127.0.0.1:26656" --rpc.laddr "tcp://127.0.0.1:26657" --proxy_app "tcp://127.0.0.1:26658" --p2p.persistent_peers "017e3b0c9a050091cc2bc609af9fb861d3710215@127.0.0.1:26666"
 
 echo -e "\nStarting the second node ($V2)"
-screen -dmS n2 eved start --home $V2 --moniker $MONIKER2 --address "tcp://0.0.0.0:26668" --api.address "tcp://0.0.0.0:1327" --grpc-web.address "0.0.0.0:9101" --grpc.address "0.0.0.0:9100" --p2p.laddr "tcp://127.0.0.1:26666" --rpc.laddr "tcp://127.0.0.1:26667" --proxy_app "tcp://127.0.0.1:26668" --p2p.persistent_peers "$KEY1_NODE_ID@127.0.0.1:26656"
+screen -dmS n2 eved start --home $V2 --moniker $MONIKER2 --address "tcp://0.0.0.0:26668" --api.address "tcp://0.0.0.0:1327" --grpc-web.address "0.0.0.0:9101" --grpc.address "0.0.0.0:9100" --p2p.laddr "tcp://127.0.0.1:26666" --rpc.laddr "tcp://127.0.0.1:26667" --proxy_app "tcp://127.0.0.1:26668" --p2p.persistent_peers "017e3b0c9a050091cc2bc609af9fb861d3710215@127.0.0.1:26656"

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -82,7 +82,7 @@ cp $TESTNETS_SHARED_DIR/config/genesis.json $V1/config/genesis.json
 eved add-genesis-account eve1hj5fveer5cjtn4wd6wstzugjfdxzl0xpysfwwn 100000000ueve --keyring-backend $KEYRING --home $V1
 eved add-genesis-account eve1hj5fveer5cjtn4wd6wstzugjfdxzl0xpysfwwn 100000000ueve --keyring-backend $KEYRING --home $TESTNETS_SHARED_DIR # also add to main genesis
 
-eved gentx $KEY 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V1 --moniker $MONIKER1 --commission-rate=0.10 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" #--node-id aaae33661a8286150ad54a512b04bbb96e72b68a --ip 127.0.0.1
+eved gentx $KEY 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V1 --moniker $MONIKER1 --commission-rate=0.10 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" --ip 127.0.0.1
 
 # Key 2.
 mkdir -p $V2/config
@@ -91,7 +91,10 @@ cp $TESTNETS_SHARED_DIR/config/genesis.json $V2/config/genesis.json
 eved add-genesis-account eve1j4rtuq6zm5mmw9xcjmm7gymlj39tvwnt9h4sm2 100000000ueve --keyring-backend $KEYRING --home $V2
 eved add-genesis-account eve1j4rtuq6zm5mmw9xcjmm7gymlj39tvwnt9h4sm2 100000000ueve --keyring-backend $KEYRING --home $TESTNETS_SHARED_DIR
 
-eved gentx $KEY2 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V2 --moniker $MONIKER2 --commission-rate=0.10 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" #--node-id bbbe33661a8286150ad54a512b04bbb96e72b68a  --ip 127.0.0.1 
+eved gentx $KEY2 1000000ueve --keyring-backend $KEYRING --chain-id $CHAINID --home $V2 --moniker $MONIKER2 --commission-rate=0.10 --commission-max-rate=1.0 --commission-max-change-rate=0.01 --min-self-delegation "1" --ip 127.0.0.1
+
+KEY1_NODE_ID=`eved tendermint show-node-id --home $V1`
+KEY2_NODE_ID=`eved tendermint show-node-id --home $V2`
 
 # save gentxs back to the root dir
 mkdir -p $TESTNETS_SHARED_DIR/config/gentx
@@ -121,9 +124,10 @@ cp $TESTNETS_SHARED_DIR/config/genesis.json $V1/config/genesis.json
 cp $TESTNETS_SHARED_DIR/config/genesis.json $V2/config/genesis.json
 
 
-# moniker 1 starts a node normally with default values
+# goal is to do this via each docker container. I guess we could support screens too if someone wanted that
+# 6:04PM INF Error reconnecting to peer. Trying again addr={"id":"aaae33661a8286150ad54a512b04bbb96e72b68a","ip":"127.0.0.1","port":26657} err="auth failure: secret conn failed: proto: BytesValue: wiretype end group for non-group" module=p2p tries=0
 echo -e "\nStarting the first node ($V1)"
-screen -dmS n1 eved start --home $V1 --moniker $MONIKER1 --address "tcp://0.0.0.0:26658" --api.address "tcp://0.0.0.0:1317" --grpc-web.address "0.0.0.0:9091" --grpc.address "0.0.0.0:9090" --p2p.laddr "tcp://127.0.0.1:26656" --rpc.laddr "tcp://127.0.0.1:26657" --proxy_app "tcp://127.0.0.1:26658" --p2p.persistent_peers "bbbe33661a8286150ad54a512b04bbb96e72b68a@127.0.0.1:26667"
+screen -dmS n1 eved start --home $V1 --moniker $MONIKER1 --address "tcp://0.0.0.0:26658" --api.address "tcp://0.0.0.0:1317" --grpc-web.address "0.0.0.0:9091" --grpc.address "0.0.0.0:9090" --p2p.laddr "tcp://127.0.0.1:26656" --rpc.laddr "tcp://127.0.0.1:26657" --proxy_app "tcp://127.0.0.1:26658" --p2p.persistent_peers "$KEY2_NODE_ID@127.0.0.1:26666"
 
 echo -e "\nStarting the second node ($V2)"
-screen -dmS n2 eved start --home $V2 --moniker $MONIKER2 --address "tcp://0.0.0.0:26668" --api.address "tcp://0.0.0.0:1327" --grpc-web.address "0.0.0.0:9101" --grpc.address "0.0.0.0:9100" --p2p.laddr "tcp://127.0.0.1:26666" --rpc.laddr "tcp://127.0.0.1:26667" --proxy_app "tcp://127.0.0.1:26668" --p2p.persistent_peers "aaae33661a8286150ad54a512b04bbb96e72b68a@127.0.0.1:26657"
+screen -dmS n2 eved start --home $V2 --moniker $MONIKER2 --address "tcp://0.0.0.0:26668" --api.address "tcp://0.0.0.0:1327" --grpc-web.address "0.0.0.0:9101" --grpc.address "0.0.0.0:9100" --p2p.laddr "tcp://127.0.0.1:26666" --rpc.laddr "tcp://127.0.0.1:26667" --proxy_app "tcp://127.0.0.1:26668" --p2p.persistent_peers "$KEY1_NODE_ID@127.0.0.1:26656"


### PR DESCRIPTION
Closes #31 

Build image of eve in the current dir with arch

gentx & stuff

start 2 test nodes using that volume in the ./testnets folder
